### PR TITLE
Better API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Busted.cache? do
 end
 #=> true
 
-Busted.cache_invalidations do
+Busted.run do
   class Pizza
   end
 end
-#=> {:method=>0, :constant=>1}
+#=> {:invalidations=>{:method=>0, :constant=>1}}
 ```
 
 *Method Cache*
@@ -68,10 +68,10 @@ Busted.cache? do
 end
 #=> false
 
-Busted.cache_invalidations do
+Busted.run do
   pizza = "pizza"
 end
-#=> {:method=>0, :constant=>0}
+#=> {:invalidations=>{:method=>0, :constant=>0}}
 ```
 
 ## Installation

--- a/lib/busted.rb
+++ b/lib/busted.rb
@@ -1,31 +1,26 @@
 require "busted/version"
+require "busted/profiler"
 
 module Busted
   extend self
 
-  def cache_invalidations(&blk)
-    starting = counts
-    yield
-    ending = counts
-
-    [:method, :constant].each_with_object({}) do |counter, result|
-      result[counter] = ending[counter] - starting[counter]
-    end
+  def run(*args, &blk)
+    Busted::Profiler.run(*args, &blk)
   end
 
   def method_cache_invalidations(&blk)
-    cache_invalidations(&blk)[:method]
+    run(&blk)[:invalidations][:method]
   end
 
   def constant_cache_invalidations(&blk)
-    cache_invalidations(&blk)[:constant]
+    run(&blk)[:invalidations][:constant]
   end
 
   def cache?(counter = nil, &blk)
     total = if counter
               send :"#{counter}_cache_invalidations", &blk
             else
-              cache_invalidations(&blk).values.inject :+
+              run(&blk)[:invalidations].values.inject :+
             end
     total > 0
   end
@@ -36,15 +31,5 @@ module Busted
 
   def constant_cache?(&blk)
     cache? :constant, &blk
-  end
-
-  private
-
-  def counts
-    stat = RubyVM.stat
-    {
-      method:   stat[:global_method_state],
-      constant: stat[:global_constant_state]
-    }
   end
 end

--- a/lib/busted/profiler.rb
+++ b/lib/busted/profiler.rb
@@ -1,0 +1,23 @@
+require "busted/profiler/default"
+
+module Busted
+  module Profiler
+    extend self
+
+    def run(*args, &blk)
+      klass(args.first).run(&blk)
+    end
+
+    private
+
+    def klass(profiler)
+      Busted::Profiler.const_get name(profiler)
+    rescue NameError
+      fail ArgumentError, "profiler `#{profiler}' does not exist"
+    end
+
+    def name(profiler)
+      (profiler || :default).to_s.tap { |s| s[0] = s[0].upcase }
+    end
+  end
+end

--- a/lib/busted/profiler/default.rb
+++ b/lib/busted/profiler/default.rb
@@ -1,0 +1,29 @@
+module Busted
+  module Profiler
+    module Default
+      extend self
+
+      def run(&blk)
+        starting = counts
+        yield
+        ending = counts
+
+        report = { invalidations: {} }
+
+        [:method, :constant].each_with_object(report) do |counter, result|
+          result[:invalidations][counter] = ending[counter] - starting[counter]
+        end
+      end
+
+      private
+
+      def counts
+        stat = RubyVM.stat
+        {
+          method:   stat[:global_method_state],
+          constant: stat[:global_constant_state]
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4
- Replace `#cache_invalidations` with `#run` for greater flexibility
- `#run` returns a `Hash` with `:invalidations` key
- Add `Busted::Profiler` module for various profilers
  - Each profiler adheres to duck type by defining `#run`
  - Add `Default` profiler
